### PR TITLE
Some minor bugfixes and code clarifications

### DIFF
--- a/bin/daikon
+++ b/bin/daikon
@@ -48,13 +48,13 @@ def get_argument_parser():
                        help='Sample translations from the model after each epoch. (default: %(default)s)')
 
     # translate
-    sample = subparsers.add_parser('translate', help='Use a trained model to translate new text.')
-    sample.add_argument('-m', '--load_from', default='model',
+    translate = subparsers.add_parser('translate', help='Use a trained model to translate new text.')
+    translate.add_argument('-m', '--load_from', default='model',
                         help='the folder to load model and vocabulary files from. (default: %(default)s)')
-    sample.add_argument('-i', '--input', type=str, required=False, default=None,
+    translate.add_argument('-i', '--input', type=str, required=False, default=None,
                         help='File that should be translated, one sentence per line.' +
                         ' If omitted, daikon assumes input from STDIN.')
-    sample.add_argument('-o', '--output', type=str, required=False, default=None,
+    translate.add_argument('-o', '--output', type=str, required=False, default=None,
                         help='File translations should be written to. If omitted, daikon writes to STDOUT.')
 
     # score

--- a/bin/daikon
+++ b/bin/daikon
@@ -129,6 +129,11 @@ def _set_up_logging(args):
 
     # log to logfile
     if args.action == 'train':
+        # create folders for model and logs if they don't exist yet
+        for folder in [args.save_to, args.log_to]:
+            if not os.path.exists(folder):
+                os.makedirs(folder)
+
         logfile = os.path.join(args.log_to, C.TRAINING_LOG_FILENAME)
         file_handler = logging.FileHandler(filename=logfile, mode="w")
         file_handler.setLevel(logging.DEBUG)

--- a/daikon/compgraph.py
+++ b/daikon/compgraph.py
@@ -33,7 +33,7 @@ def define_computation_graph(source_vocab_size: int, target_vocab_size: int, bat
 
     with tf.variable_scope("Embeddings"):
         source_embedding = tf.get_variable('source_embedding', [source_vocab_size, C.EMBEDDING_SIZE])
-        target_embedding = tf.get_variable('target_embedding', [source_vocab_size, C.EMBEDDING_SIZE])
+        target_embedding = tf.get_variable('target_embedding', [target_vocab_size, C.EMBEDDING_SIZE])
 
         encoder_inputs_embedded = tf.nn.embedding_lookup(source_embedding, encoder_inputs)
         decoder_inputs_embedded = tf.nn.embedding_lookup(target_embedding, decoder_inputs)

--- a/daikon/reader.py
+++ b/daikon/reader.py
@@ -55,7 +55,7 @@ def read(filename: str, vocab) -> Iterator[List[int]]:
     """
     lines = read_lines(filename)
     for line in lines:
-        yield [vocab.get_id(word) for word in line]
+        yield vocab.get_ids(line)
 
 
 def read_parallel(source_filename: str,
@@ -116,8 +116,7 @@ def pad_sequence(word_ids: List[int], pad_id: int, max_length: int) -> List[int]
     return padded_sequence
 
 
-NestedIds = List[List[int]]
-ReaderTuple = Tuple[NestedIds, NestedIds]
+ReaderTuple = Tuple[List[int], List[int]]
 
 
 def iterate(reader_ids: List[ReaderTuple], batch_size: int, shuffle: bool = True):

--- a/daikon/train.py
+++ b/daikon/train.py
@@ -60,7 +60,7 @@ def train(source_data: str,
           log_to: str,
           sample_after_epoch: bool,
           **kwargs) -> None:
-    """Trains a language model. See argument description in `bin/romanesco`."""
+    """Trains a language model. See argument description in `bin/daikon`."""
 
     logger.info("Creating vocabularies.")
 

--- a/daikon/train.py
+++ b/daikon/train.py
@@ -62,11 +62,6 @@ def train(source_data: str,
           **kwargs) -> None:
     """Trains a language model. See argument description in `bin/romanesco`."""
 
-    # create folders for model and logs if they don't exist yet
-    for folder in [save_to, log_to]:
-        if not os.path.exists(folder):
-            os.makedirs(folder)
-
     logger.info("Creating vocabularies.")
 
     # create vocabulary to map words to ids, for source and target

--- a/daikon/vocab.py
+++ b/daikon/vocab.py
@@ -74,7 +74,7 @@ class Vocabulary:
     def get_words(self, ids: List[int]):
         return [self.get_word(id) for id in ids]
 
-    def save(self, filepath):
+    def save(self, filepath: str):
         """Writes this vocabulary to a file in JSON format."""
         with open(filepath, 'w') as f:
             json.dump(self._id, f, indent=4)

--- a/daikon/vocab.py
+++ b/daikon/vocab.py
@@ -74,10 +74,6 @@ class Vocabulary:
     def get_words(self, ids: List[int]):
         return [self.get_word(id) for id in ids]
 
-    def get_random_id(self):
-        """Returns the id of a random word."""
-        return random.choice(list(self._id.values()))
-
     def save(self, filepath):
         """Writes this vocabulary to a file in JSON format."""
         with open(filepath, 'w') as f:


### PR DESCRIPTION
- fixed a TensorFlow `InvalidArgumentError` when source and target vocabularies have different sizes (e.g. when training on the 10k EN/ES test set in the repo)
- create `model` and `logs` directories before using the logger the first time (this caused daikon to crash when `logs` didn't exist)
- updated some names and removed `Vocabulary.get_random_id()`, which were probably remnants from romanesco?
- added and corrected some type hints